### PR TITLE
Optimize Hermit camera and lidar sensors

### DIFF
--- a/hermit/model.sdf
+++ b/hermit/model.sdf
@@ -426,26 +426,16 @@
             <motorType>velocity</motorType>
         </plugin>
 
-        <!-- camera realsense T265 -->
-        <include merge='true'>
-            <uri>model://realsense_t265</uri>
-            <pose>0.1125 0.020 0.013 -1.5707963267948966 3.141592653589793 1.5707963267948966</pose>
-        </include>
-        <joint name="CameraJoint" type="fixed">
-            <parent>base_link</parent>
-            <child>realsense_t265/base</child>
-            <pose relative_to="base_link">0.1125 0.020 0.013 -1.5707963267948966 3.141592653589793 1.5707963267948966</pose>
-        </joint>
-
-        <!-- camera realsense D455 -->
+        <!-- D455 montada na frente do drone. Os sensores camera do Gazebo
+             observam no eixo +X; rotacao nula mantem RGB e depth para frente. -->
         <include merge="true">
             <uri>model://realsense_d455</uri>
-            <pose>0.129227 0 -0.0507 0 1.5707963267948966 0</pose>
+            <pose>0.129227 0 -0.0507 0 0 0</pose>
         </include>
         <joint name="CameraJointD455" type="fixed">
             <parent>base_link</parent>
             <child>realsense_d455/base</child>
-            <pose relative_to="base_link">0.129227 0 -0.0507 0 1.5707963267948966 0</pose>
+            <pose relative_to="base_link">0.129227 0 -0.0507 0 0 0</pose>
         </joint>
 
         <!-- ===================== LiDAR 2D tipo RPLIDAR A2 ===================== -->
@@ -502,10 +492,11 @@
 
             <!-- Sensor LiDAR 2D (Ignition / gz-sim) -->
             <sensor name="rplidar_a2" type="gpu_lidar">
-                <always_on>1</always_on>
+                <!-- Ativado sob demanda pela bridge lazy. -->
+                <always_on>0</always_on>
                 <update_rate>10</update_rate>
                 <pose>0 0 0.03 0 0 0</pose>
-                <topic>/scan</topic> <!-- LaserScan em /scan (+ /scan/points) -->
+                <topic>/scan</topic> <!-- Somente LaserScan cruza a bridge ROS. -->
                 <lidar>
                     <scan>
                         <horizontal>

--- a/realsense_d455/model.sdf
+++ b/realsense_d455/model.sdf
@@ -36,15 +36,17 @@
       <!-- Câmera colorida (RGB) -->
       <sensor name="color_camera_sensor" type="camera">
         <pose>0 0.0475 0 0 0 0</pose>
-        <always_on>1</always_on>
+        <!-- Ativada sob demanda pela bridge lazy. -->
+        <always_on>0</always_on>
         <update_rate>30</update_rate>
         <!-- Publicar no tópico /camera/color/image_raw -->
         <topic>/camera/color/image_raw</topic>
         <camera>
           <horizontal_fov>1.39626</horizontal_fov>
           <image>
-            <width>1280</width>
-            <height>720</height>
+            <!-- Perfil D455 de menor custo: 56% menos pixels que 1280x720. -->
+            <width>848</width>
+            <height>480</height>
             <format>R8G8B8</format>
           </image>
           <clip>
@@ -57,14 +59,16 @@
       <!-- Câmera de profundidade (float32) -->
       <sensor name="depth_camera_sensor" type="depth_camera">
         <pose>0 0.010 0 0 0 0</pose>
-        <always_on>1</always_on>
+        <!-- Ativada sob demanda pela bridge lazy. -->
+        <always_on>0</always_on>
         <update_rate>30</update_rate>
         <topic>/camera/depth/image_rect_raw</topic>
         <camera>
           <horizontal_fov>1.39626</horizontal_fov>
           <image>
-            <width>1280</width>
-            <height>720</height>
+            <!-- Perfil nativo D455 848x480, alinhado ao RGB. -->
+            <width>848</width>
+            <height>480</height>
             <format>R_FLOAT32</format>
           </image>
           <clip>
@@ -74,56 +78,12 @@
         </camera>
       </sensor>
 
-      <!-- Câmera IR1 pseudo-colorida (depth_camera) -->
-      <sensor name="infra1_camera_sensor" type="depth_camera">
-        <pose>0 -0.0115 0 0 0 0</pose>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <!-- Publicar no tópico /camera/infra1/image_rect_raw -->
-        <topic>/camera/infra1/image_rect_raw</topic>
-        <camera>
-          <horizontal_fov>1.39626</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>R_FLOAT32</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>10.0</far>
-          </clip>
-          <!-- Ativa visualização pseudo-color no Gazebo -->
-          <visualize>true</visualize>
-        </camera>
-      </sensor>
-      
-      <!-- Câmera IR2 monocromática (L8) -->
-      <sensor name="infra2_camera_sensor" type="camera">
-        <pose>0 -0.0475 0 0 0 0</pose>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <!-- Publicar no tópico /camera/infra2/image_rect_raw -->
-        <topic>/camera/infra2/image_rect_raw</topic>
-        <camera>
-          <horizontal_fov>1.39626</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>10.0</far>
-          </clip>
-        </camera>
-      </sensor>
-      
       <!-- Giroscópio -->
       <sensor name="gyro_sensor" type="imu">
         <pose>-0.00998 0.00001728 0.0074 0 0 0</pose>
-        <always_on>1</always_on>
+        <always_on>0</always_on>
         <update_rate>200</update_rate>
-        <topic>/camera/gyro/sample</topic>
+        <topic>/camera/d455/gyro/sample</topic>
         <imu>
           <angular_velocity>
             <x>
@@ -157,9 +117,9 @@
       <!-- Acelerômetro -->
       <sensor name="accel_sensor" type="imu">
         <pose>-0.00998 0.00001728 0.0074 0 0 0</pose>
-        <always_on>1</always_on>
+        <always_on>0</always_on>
         <update_rate>200</update_rate>
-        <topic>/camera/accel/sample</topic>
+        <topic>/camera/d455/accel/sample</topic>
         <imu>
           <linear_acceleration>
             <x>


### PR DESCRIPTION
## Summary

- reduce the D455 RGB and depth profile from 1280x720 to 848x480
- remove the unused D455 infrared render sensors and keep only RGB, depth and IMU streams
- make D455 and lidar sensors demand-driven for the lazy ROS bridge
- namespace D455 IMU topics to avoid collisions
- remove the unused T265 from the active Hermit model
- mount the D455 with its RGB and depth optical axes facing forward

## Why

The previous model rendered and transported sensor data that the simulator does not consume. That work substantially reduced Gazebo real-time factor once ros_gz_bridge was enabled. These changes keep only the required streams and avoid rendering them without subscribers.

## Validation

- xmllint validation for hermit/model.sdf and realsense_d455/model.sdf
- git diff whitespace validation
- functional Gazebo test with forward RGB/depth, valid 32FC1 depth frames, D455 IMU and lidar LaserScan
