### PR TITLE
realsense: correct D455 depth CameraInfo calibration

### DIFF
--- a/realsense_d455/model.sdf
+++ b/realsense_d455/model.sdf
@@ -75,6 +75,31 @@
             <near>0.1</near>
             <far>10.0</far>
           </clip>
+          <!--
+            O DepthCamera do Gazebo Garden usa os defaults 320x240 do
+            SDFormat (fx=fy=277, cx=160, cy=120) no CameraInfo quando a lente
+            nao declara intrinsecos. Estes valores correspondem ao perfil
+            848x480 e ao horizontal_fov de 80 graus definido acima.
+          -->
+          <lens>
+            <type>gnomonical</type>
+            <scale_to_hfov>true</scale_to_hfov>
+            <intrinsics>
+              <fx>505.3052686175046</fx>
+              <fy>505.3052686175046</fy>
+              <cx>424.0</cx>
+              <cy>240.0</cy>
+              <s>0.0</s>
+            </intrinsics>
+            <projection>
+              <p_fx>505.3052686175046</p_fx>
+              <p_fy>505.3052686175046</p_fy>
+              <p_cx>424.0</p_cx>
+              <p_cy>240.0</p_cy>
+              <tx>0.0</tx>
+              <ty>0.0</ty>
+            </projection>
+          </lens>
         </camera>
       </sensor>
 


### PR DESCRIPTION
## What changed

- declares the D455 depth camera perspective intrinsics for the configured
  848×480 stream;
- declares the matching projection parameters instead of relying on SDFormat
  defaults.

## Why

Gazebo Garden was publishing the SDFormat fallback calibration (`fx=fy=277`,
`cx=160`, `cy=120`), which corresponds to 320×240, while the depth image is
848×480. The image data was valid, but consumers performing projection or
reconstruction received inconsistent `CameraInfo`.

## Impact

The depth stream remains `848×480` / `32FC1`, but its `K` matrix now matches
the rendered image and RGB profile: `fx=fy=505.3052686175046`, `cx=424`,
`cy=240`.

## Validation

- `gz sdf -k realsense_d455/model.sdf`;
- Gazebo Garden runtime with the Hermit model;
- ROS 2 `CameraInfo` inspected from
  `/pequi/hermit/camera/d455/depth/camera_info`;
- depth frame captured with approximately 70% valid pixels.
